### PR TITLE
Ignore high_scores.txt and remove it from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+high_scores.txt

--- a/high_scores.txt
+++ b/high_scores.txt
@@ -1,5 +1,0 @@
-Knuckleheads High Scores:
-Lucy................ 860
-Snoopy.............. 485
-Linus............... 230
-Woodstock........... 95


### PR DESCRIPTION
Since `high_scores.txt` gets regenerated on each run we don't really need it in version control.

![SAIL!](http://gifs.joelglovier.com/fail/cat-fail.gif)
